### PR TITLE
Use DefaultTextStyle for not given textStyle in constructor

### DIFF
--- a/lib/mdeditor.dart
+++ b/lib/mdeditor.dart
@@ -82,9 +82,13 @@ class _MarkdownEditorState extends State<MarkdownEditor>
 
   @override
   Widget build(BuildContext context) {
+    final DefaultTextStyle defaultTextStyle = DefaultTextStyle.of(context);
+    TextStyle effectiveTextStyle = widget.textStyle;
+    if (widget.textStyle == null || widget.textStyle.inherit)
+      effectiveTextStyle = defaultTextStyle.style.merge(widget.textStyle);
     double topOffset = _decoration.labelStyle?.fontSize ?? 0.0;
     if (_decoration.hintStyle != null) {
-      topOffset += _decoration.hintStyle.fontSize - widget.textStyle.fontSize;
+      topOffset += _decoration.hintStyle.fontSize - effectiveTextStyle.fontSize;
     }
     /*if(_decoration.contentPadding!=null){
       topOffset += _decoration.contentPadding.vertical/2;
@@ -99,7 +103,7 @@ class _MarkdownEditorState extends State<MarkdownEditor>
           child: MarkdownViewer(
             content: textEditingController.text,
             collapsible: false,
-            textStyle: widget.textStyle,
+            textStyle: effectiveTextStyle,
             highlightedTextStyle: widget.highlightedTextStyle,
             tokenConfigs: widget.tokenConfigs,
             /*formatTypes: [
@@ -115,8 +119,8 @@ class _MarkdownEditorState extends State<MarkdownEditor>
             autofocus: widget.autoFocus ?? true,
             keyboardType: TextInputType.multiline,
             maxLines: null,
-            style: widget.textStyle.copyWith(color: Colors.transparent),
-//            style: widget.textStyle.copyWith(color: Colors.grey.withOpacity(0.1)),
+            style: effectiveTextStyle.copyWith(color: Colors.transparent),
+//            style: effectiveTextStyle.copyWith(color: Colors.grey.withOpacity(0.1)),
             decoration: _decoration,
             onSaved: widget.onSaved),
       ],


### PR DESCRIPTION
The `textStyle` parameter in the constructor is not required, but it's accessed:
https://github.com/infitio/flutter_markdown/blob/4fb973415cf472f133e6c2e7a354bee1d9c095c3/lib/mdeditor.dart#L87

Without the fix and not providing a text style it throws a NoSuchMethodError by accessing the fontSize